### PR TITLE
Issue/3 multiple streams

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Secrets and internal config files
 **/.secrets/*
+*.env
 
 # Ignore meltano internal cache and sqlite systemdb
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,28 @@
+---
+variables:
+  PYTHON_IMAGE_TAG: 3.9.7
+stages:
+  - build
+  - deploy
+
+build_package:
+  stage: build
+  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/python:$PYTHON_IMAGE_TAG
+  artifacts:
+    paths:
+      - dist
+  script:
+    - curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3 -
+    - export PATH=$HOME/.local/bin:$PATH
+    - poetry build
+
+deploy_package:
+  stage: deploy
+  image: ${CI_DEPENDENCY_PROXY_GROUP_IMAGE_PREFIX}/python:$PYTHON_IMAGE_TAG
+  rules:
+    - if: '$CI_COMMIT_TAG =~ /^v\d+\.\d+\.\d+$/'
+  script:
+    - curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3 -
+    - export PATH=$HOME/.local/bin:$PATH
+    - poetry config repositories.privatepypi ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/pypi
+    - poetry publish --repository privatepypi --username gitlab-ci-token --password ${CI_JOB_TOKEN}

--- a/meltano.yml
+++ b/meltano.yml
@@ -4,37 +4,73 @@ plugins:
   extractors:
     - name: tap-rest-api-msdk
       namespace: tap_rest_api_msdk
-      executable: ./tap-rest-api-msdk.sh
+      # executable: ./tap-rest-api-msdk.sh
+      pip_url: .
       capabilities:
         - state
         - catalog
         - discover
       settings:
-        - name: api_url
         - name: name
+          kind: string
+        - name: api_url
+          kind: string
         - name: path
+          kind: string
         - name: params
+          kind: object
         - name: headers
+          kind: object
         - name: records_path
+          kind: string
         - name: primary_keys
-        - name: replication_key
+          kind: array
         - name: except_keys
-        - name: num_inference_records
+          kind: array
+        - name: pagination_request_style
+        - name: pagination_response_style
+        - name: pagination_page_size
+          kind: integer
+        - name: streams
+          kind: array
+        - name: streams_auth
+          kind: object
+      # config:
+      #   name: us_earthquakes
+      #   api_url: https://earthquake.usgs.gov/fdsnws
+      #   path: /event/1/query
+      #   params:
+      #     format: geojson
+      #     starttime: "2014-01-01"
+      #     endtime: "2014-01-02"
+      #     minmagnitude: 1
+      #   primary_keys:
+      #     - id
+      #   records_path: "$.features[*]"
+      #   num_inference_records: 100
+      #   select:
+      #     - "*.*"
       config:
-        name: us_earthquakes
-        api_url: https://earthquake.usgs.gov/fdsnws
-        path: /event/1/query
-        params:
-          format: geojson
-          starttime: "2014-01-01"
-          endtime: "2014-01-02"
-          minmagnitude: 1
-        primary_keys:
-          - id
-        records_path: "$.features[*]"
-        num_inference_records: 100
-      select:
-        - '*.*'
+        streams:
+          - name: us_earthquakes
+            api_url: https://earthquake.usgs.gov/fdsnws
+            path: /event/1/query
+            params:
+              format: geojson
+              starttime: "2014-01-01"
+              endtime: "2014-01-02"
+              minmagnitude: 1
+            primary_keys:
+              - id
+            records_path: "$.features[*]"
+            num_inference_records: 100
+            select:
+              - "*.*"
+        # If you need auth, but it in a separate object with properties named after streams
+        # steams_auth:
+        #   us_earthquakes:
+        #     headers:
+        #       "X-ApiKeys": "my secret api keys"
   loaders:
     - name: target-jsonl
       variant: andyh1203

--- a/poetry.lock
+++ b/poetry.lock
@@ -30,7 +30,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "backports.entry-points-selectable"
-version = "1.1.0"
+version = "1.1.1"
 description = "Compatibility shim providing selectable entry points for older implementations"
 category = "dev"
 optional = false
@@ -41,11 +41,11 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=4.6)", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "pytest-mypy", "pytest-checkdocs (>=2.4)", "pytest-enabler (>=1.0.1)"]
+testing = ["pytest", "pytest-flake8", "pytest-cov", "pytest-black (>=0.3.7)", "pytest-mypy", "pytest-checkdocs (>=2.4)", "pytest-enabler (>=1.0.1)"]
 
 [[package]]
 name = "black"
-version = "21.9b0"
+version = "21.12b0"
 description = "The uncompromising code formatter."
 category = "dev"
 optional = false
@@ -57,16 +57,15 @@ dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0,<1"
 platformdirs = ">=2"
-regex = ">=2020.1.8"
 tomli = ">=0.2.6,<2.0.0"
-typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\""}
+typed-ast = {version = ">=1.4.2", markers = "python_version < \"3.8\" and implementation_name == \"cpython\""}
 typing-extensions = ">=3.10.0.0"
 
 [package.extras]
 colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.6.0)", "aiohttp-cors (>=0.4.0)"]
+d = ["aiohttp (>=3.7.4)"]
 jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-python2 = ["typed-ast (>=1.4.2)"]
+python2 = ["typed-ast (>=1.4.3)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
@@ -90,7 +89,7 @@ pycparser = "*"
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.7"
+version = "2.0.9"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 category = "main"
 optional = false
@@ -128,6 +127,14 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "contextlib2"
+version = "21.6.0"
+description = "Backports and enhancements for the contextlib module"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "cryptography"
 version = "3.4.8"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
@@ -150,7 +157,7 @@ test = ["pytest (>=6.0)", "pytest-cov", "pytest-subtests", "pytest-xdist", "pret
 name = "dataclasses"
 version = "0.8"
 description = "A backport of the dataclasses module for Python 3.6"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6, <3.7"
 
@@ -164,7 +171,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "distlib"
-version = "0.3.3"
+version = "0.3.4"
 description = "Distribution utilities"
 category = "dev"
 optional = false
@@ -172,7 +179,7 @@ python-versions = "*"
 
 [[package]]
 name = "filelock"
-version = "3.3.1"
+version = "3.4.0"
 description = "A platform independent file lock."
 category = "dev"
 optional = false
@@ -214,7 +221,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.8.1"
+version = "4.8.3"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -227,11 +234,11 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
-testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "importlib-resources"
-version = "5.3.0"
+version = "5.4.0"
 description = "Read resources from Python packages"
 category = "dev"
 optional = false
@@ -343,14 +350,14 @@ python-versions = "*"
 
 [[package]]
 name = "packaging"
-version = "21.0"
+version = "21.3"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-pyparsing = ">=2.0.2"
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
 name = "pathspec"
@@ -428,11 +435,11 @@ python-versions = "*"
 
 [[package]]
 name = "py"
-version = "1.10.0"
+version = "1.11.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "pycodestyle"
@@ -444,7 +451,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pycparser"
-version = "2.20"
+version = "2.21"
 description = "C parser in Python"
 category = "main"
 optional = false
@@ -487,11 +494,14 @@ test = ["pytest (>=4.0.1,<5.0.0)", "pytest-cov (>=2.6.0,<3.0.0)", "pytest-runner
 
 [[package]]
 name = "pyparsing"
-version = "2.4.7"
+version = "3.0.6"
 description = "Python parsing module"
 category = "dev"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = ">=3.6"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pyrsistent"
@@ -551,14 +561,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
-name = "regex"
-version = "2021.10.8"
-description = "Alternative regular expression module, to replace re."
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "requests"
 version = "2.26.0"
 description = "Python HTTP for Humans."
@@ -586,16 +588,18 @@ python-versions = "*"
 
 [[package]]
 name = "singer-sdk"
-version = "0.3.11"
+version = "0.3.17"
 description = "A framework for building Singer taps"
 category = "main"
 optional = false
-python-versions = ">=3.6.2,<3.10"
+python-versions = ">=3.6.2,<3.11"
 
 [package.dependencies]
 backoff = ">=1.8.0,<2.0"
 click = ">=8.0,<9.0"
+contextlib2 = {version = "*", markers = "python_version < \"3.7\""}
 cryptography = ">=3.4.6,<4.0.0"
+dataclasses = {version = "*", markers = "python_version < \"3.7\""}
 importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 inflection = ">=0.5.1,<0.6.0"
 joblib = ">=1.0.1,<2.0.0"
@@ -619,7 +623,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "snowballstemmer"
-version = "2.1.0"
+version = "2.2.0"
 description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
 category = "dev"
 optional = false
@@ -635,7 +639,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tomli"
-version = "1.2.1"
+version = "1.2.3"
 description = "A lil' TOML parser"
 category = "dev"
 optional = false
@@ -674,7 +678,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-requests"
-version = "2.25.11"
+version = "2.26.2"
 description = "Typing stubs for requests"
 category = "dev"
 optional = false
@@ -682,11 +686,11 @@ python-versions = "*"
 
 [[package]]
 name = "typing-extensions"
-version = "3.10.0.2"
-description = "Backported and Experimental Type Hints for Python 3.5+"
+version = "4.0.1"
+description = "Backported and Experimental Type Hints for Python 3.6+"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=3.6"
 
 [[package]]
 name = "urllib3"
@@ -703,7 +707,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "virtualenv"
-version = "20.8.1"
+version = "20.10.0"
 description = "Virtual Python Environment builder"
 category = "dev"
 optional = false
@@ -712,14 +716,14 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 [package.dependencies]
 "backports.entry-points-selectable" = ">=1.0.4"
 distlib = ">=0.3.1,<1"
-filelock = ">=3.0.0,<4"
+filelock = ">=3.2,<4"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 importlib-resources = {version = ">=1.0", markers = "python_version < \"3.7\""}
 platformdirs = ">=2,<3"
 six = ">=1.9.0,<2"
 
 [package.extras]
-docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)"]
+docs = ["proselint (>=0.10.2)", "sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=21.3)"]
 testing = ["coverage (>=4)", "coverage-enable-subprocess (>=1)", "flaky (>=3)", "pytest (>=4)", "pytest-env (>=0.6.2)", "pytest-freezegun (>=0.4.1)", "pytest-mock (>=2)", "pytest-randomly (>=1)", "pytest-timeout (>=1)", "packaging (>=20.0)"]
 
 [[package]]
@@ -753,12 +757,12 @@ backoff = [
     {file = "backoff-1.8.0.tar.gz", hash = "sha256:c7187f15339e775aec926dc6e5e42f8a3ad7d3c2b9a6ecae7b535000f70cd838"},
 ]
 "backports.entry-points-selectable" = [
-    {file = "backports.entry_points_selectable-1.1.0-py2.py3-none-any.whl", hash = "sha256:a6d9a871cde5e15b4c4a53e3d43ba890cc6861ec1332c9c2428c92f977192acc"},
-    {file = "backports.entry_points_selectable-1.1.0.tar.gz", hash = "sha256:988468260ec1c196dab6ae1149260e2f5472c9110334e5d51adcb77867361f6a"},
+    {file = "backports.entry_points_selectable-1.1.1-py2.py3-none-any.whl", hash = "sha256:7fceed9532a7aa2bd888654a7314f864a3c16a4e710b34a58cfc0f08114c663b"},
+    {file = "backports.entry_points_selectable-1.1.1.tar.gz", hash = "sha256:914b21a479fde881635f7af5adc7f6e38d6b274be32269070c53b698c60d5386"},
 ]
 black = [
-    {file = "black-21.9b0-py3-none-any.whl", hash = "sha256:380f1b5da05e5a1429225676655dddb96f5ae8c75bdf91e53d798871b902a115"},
-    {file = "black-21.9b0.tar.gz", hash = "sha256:7de4cfc7eb6b710de325712d40125689101d21d25283eed7e9998722cf10eb91"},
+    {file = "black-21.12b0-py3-none-any.whl", hash = "sha256:a615e69ae185e08fdd73e4715e260e2479c861b5740057fde6e8b4e3b7dd589f"},
+    {file = "black-21.12b0.tar.gz", hash = "sha256:77b80f693a569e2e527958459634f18df9b0ba2625ba4e0c2d5da5be42e6f2b3"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -817,8 +821,8 @@ cffi = [
     {file = "cffi-1.15.0.tar.gz", hash = "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954"},
 ]
 charset-normalizer = [
-    {file = "charset-normalizer-2.0.7.tar.gz", hash = "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0"},
-    {file = "charset_normalizer-2.0.7-py3-none-any.whl", hash = "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"},
+    {file = "charset-normalizer-2.0.9.tar.gz", hash = "sha256:b0b883e8e874edfdece9c28f314e3dd5badf067342e42fb162203335ae61aa2c"},
+    {file = "charset_normalizer-2.0.9-py3-none-any.whl", hash = "sha256:1eecaa09422db5be9e29d7fc65664e6c33bd06f9ced7838578ba40d58bdf3721"},
 ]
 ciso8601 = [
     {file = "ciso8601-2.2.0.tar.gz", hash = "sha256:14ad817ed31a698372d42afa81b0173d71cd1d0b48b7499a2da2a01dcc8695e6"},
@@ -830,6 +834,10 @@ click = [
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
+]
+contextlib2 = [
+    {file = "contextlib2-21.6.0-py2.py3-none-any.whl", hash = "sha256:3fbdb64466afd23abaf6c977627b75b6139a5a3e8ce38405c5b413aed7a0471f"},
+    {file = "contextlib2-21.6.0.tar.gz", hash = "sha256:ab1e2bfe1d01d968e1b7e8d9023bc51ef3509bba217bb730cee3827e1ee82869"},
 ]
 cryptography = [
     {file = "cryptography-3.4.8-cp36-abi3-macosx_10_10_x86_64.whl", hash = "sha256:a00cf305f07b26c351d8d4e1af84ad7501eca8a342dedf24a7acb0e7b7406e14"},
@@ -861,12 +869,12 @@ decorator = [
     {file = "decorator-5.1.0.tar.gz", hash = "sha256:e59913af105b9860aa2c8d3272d9de5a56a4e608db9a2f167a8480b323d529a7"},
 ]
 distlib = [
-    {file = "distlib-0.3.3-py2.py3-none-any.whl", hash = "sha256:c8b54e8454e5bf6237cc84c20e8264c3e991e824ef27e8f1e81049867d861e31"},
-    {file = "distlib-0.3.3.zip", hash = "sha256:d982d0751ff6eaaab5e2ec8e691d949ee80eddf01a62eaa96ddb11531fe16b05"},
+    {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
+    {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
 ]
 filelock = [
-    {file = "filelock-3.3.1-py3-none-any.whl", hash = "sha256:2b5eb3589e7fdda14599e7eb1a50e09b4cc14f34ed98b8ba56d33bfaafcbef2f"},
-    {file = "filelock-3.3.1.tar.gz", hash = "sha256:34a9f35f95c441e7b38209775d6e0337f9a3759f3565f6c5798f19618527c76f"},
+    {file = "filelock-3.4.0-py3-none-any.whl", hash = "sha256:2e139a228bcf56dd8b2274a65174d005c4a6b68540ee0bdbb92c76f43f29f7e8"},
+    {file = "filelock-3.4.0.tar.gz", hash = "sha256:93d512b32a23baf4cac44ffd72ccf70732aeff7b8050fcaf6d3ec406d954baf4"},
 ]
 flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
@@ -880,12 +888,12 @@ idna = [
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.8.1-py3-none-any.whl", hash = "sha256:b618b6d2d5ffa2f16add5697cf57a46c76a56229b0ed1c438322e4e95645bd15"},
-    {file = "importlib_metadata-4.8.1.tar.gz", hash = "sha256:f284b3e11256ad1e5d03ab86bb2ccd6f5339688ff17a4d797a0fe7df326f23b1"},
+    {file = "importlib_metadata-4.8.3-py3-none-any.whl", hash = "sha256:65a9576a5b2d58ca44d133c42a241905cc45e34d2c06fd5ba2bafa221e5d7b5e"},
+    {file = "importlib_metadata-4.8.3.tar.gz", hash = "sha256:766abffff765960fcc18003801f7044eb6755ffae4521c8e8ce8e83b9c9b0668"},
 ]
 importlib-resources = [
-    {file = "importlib_resources-5.3.0-py3-none-any.whl", hash = "sha256:7a65eb0d8ee98eedab76e6deb51195c67f8e575959f6356a6e15fd7e1148f2a3"},
-    {file = "importlib_resources-5.3.0.tar.gz", hash = "sha256:f2e58e721b505a79abe67f5868d99f8886aec8594c962c7490d0c22925f518da"},
+    {file = "importlib_resources-5.4.0-py3-none-any.whl", hash = "sha256:33a95faed5fc19b4bc16b29a6eeae248a3fe69dd55d4d229d2b480e23eeaad45"},
+    {file = "importlib_resources-5.4.0.tar.gz", hash = "sha256:d756e2f85dd4de2ba89be0b21dba2a3bbec2e871a42a3a16719258a11f87506b"},
 ]
 inflection = [
     {file = "inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2"},
@@ -946,8 +954,8 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 packaging = [
-    {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
-    {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pathspec = [
     {file = "pathspec-0.9.0-py2.py3-none-any.whl", hash = "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a"},
@@ -993,16 +1001,16 @@ ply = [
     {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
 ]
 py = [
-    {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
-    {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pycodestyle = [
     {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
     {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
 ]
 pycparser = [
-    {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
-    {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
+    {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
+    {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
 pydocstyle = [
     {file = "pydocstyle-6.1.1-py3-none-any.whl", hash = "sha256:6987826d6775056839940041beef5c08cc7e3d71d63149b48e36727f70144dc4"},
@@ -1017,8 +1025,8 @@ pyjwt = [
     {file = "PyJWT-1.7.1.tar.gz", hash = "sha256:8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"},
 ]
 pyparsing = [
-    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
-    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+    {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
+    {file = "pyparsing-3.0.6.tar.gz", hash = "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"},
 ]
 pyrsistent = [
     {file = "pyrsistent-0.18.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72"},
@@ -1059,55 +1067,6 @@ pytzdata = [
     {file = "pytzdata-2020.1-py2.py3-none-any.whl", hash = "sha256:e1e14750bcf95016381e4d472bad004eef710f2d6417240904070b3d6654485f"},
     {file = "pytzdata-2020.1.tar.gz", hash = "sha256:3efa13b335a00a8de1d345ae41ec78dd11c9f8807f522d39850f2dd828681540"},
 ]
-regex = [
-    {file = "regex-2021.10.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:094a905e87a4171508c2a0e10217795f83c636ccc05ddf86e7272c26e14056ae"},
-    {file = "regex-2021.10.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:981c786293a3115bc14c103086ae54e5ee50ca57f4c02ce7cf1b60318d1e8072"},
-    {file = "regex-2021.10.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b0f2f874c6a157c91708ac352470cb3bef8e8814f5325e3c5c7a0533064c6a24"},
-    {file = "regex-2021.10.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:51feefd58ac38eb91a21921b047da8644155e5678e9066af7bcb30ee0dca7361"},
-    {file = "regex-2021.10.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea8de658d7db5987b11097445f2b1f134400e2232cb40e614e5f7b6f5428710e"},
-    {file = "regex-2021.10.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1ce02f420a7ec3b2480fe6746d756530f69769292eca363218c2291d0b116a01"},
-    {file = "regex-2021.10.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:39079ebf54156be6e6902f5c70c078f453350616cfe7bfd2dd15bdb3eac20ccc"},
-    {file = "regex-2021.10.8-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ff24897f6b2001c38a805d53b6ae72267025878d35ea225aa24675fbff2dba7f"},
-    {file = "regex-2021.10.8-cp310-cp310-win32.whl", hash = "sha256:c6569ba7b948c3d61d27f04e2b08ebee24fec9ff8e9ea154d8d1e975b175bfa7"},
-    {file = "regex-2021.10.8-cp310-cp310-win_amd64.whl", hash = "sha256:45cb0f7ff782ef51bc79e227a87e4e8f24bc68192f8de4f18aae60b1d60bc152"},
-    {file = "regex-2021.10.8-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:fab3ab8aedfb443abb36729410403f0fe7f60ad860c19a979d47fb3eb98ef820"},
-    {file = "regex-2021.10.8-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:74e55f8d66f1b41d44bc44c891bcf2c7fad252f8f323ee86fba99d71fd1ad5e3"},
-    {file = "regex-2021.10.8-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d52c5e089edbdb6083391faffbe70329b804652a53c2fdca3533e99ab0580d9"},
-    {file = "regex-2021.10.8-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1abbd95cbe9e2467cac65c77b6abd9223df717c7ae91a628502de67c73bf6838"},
-    {file = "regex-2021.10.8-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9b5c215f3870aa9b011c00daeb7be7e1ae4ecd628e9beb6d7e6107e07d81287"},
-    {file = "regex-2021.10.8-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f540f153c4f5617bc4ba6433534f8916d96366a08797cbbe4132c37b70403e92"},
-    {file = "regex-2021.10.8-cp36-cp36m-win32.whl", hash = "sha256:1f51926db492440e66c89cd2be042f2396cf91e5b05383acd7372b8cb7da373f"},
-    {file = "regex-2021.10.8-cp36-cp36m-win_amd64.whl", hash = "sha256:5f55c4804797ef7381518e683249310f7f9646da271b71cb6b3552416c7894ee"},
-    {file = "regex-2021.10.8-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb2baff66b7d2267e07ef71e17d01283b55b3cc51a81b54cc385e721ae172ba4"},
-    {file = "regex-2021.10.8-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9e527ab1c4c7cf2643d93406c04e1d289a9d12966529381ce8163c4d2abe4faf"},
-    {file = "regex-2021.10.8-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:36c98b013273e9da5790ff6002ab326e3f81072b4616fd95f06c8fa733d2745f"},
-    {file = "regex-2021.10.8-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:55ef044899706c10bc0aa052f2fc2e58551e2510694d6aae13f37c50f3f6ff61"},
-    {file = "regex-2021.10.8-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:aa0ab3530a279a3b7f50f852f1bab41bc304f098350b03e30a3876b7dd89840e"},
-    {file = "regex-2021.10.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a37305eb3199d8f0d8125ec2fb143ba94ff6d6d92554c4b8d4a8435795a6eccd"},
-    {file = "regex-2021.10.8-cp37-cp37m-win32.whl", hash = "sha256:2efd47704bbb016136fe34dfb74c805b1ef5c7313aef3ce6dcb5ff844299f432"},
-    {file = "regex-2021.10.8-cp37-cp37m-win_amd64.whl", hash = "sha256:924079d5590979c0e961681507eb1773a142553564ccae18d36f1de7324e71ca"},
-    {file = "regex-2021.10.8-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:19b8f6d23b2dc93e8e1e7e288d3010e58fafed323474cf7f27ab9451635136d9"},
-    {file = "regex-2021.10.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b09d3904bf312d11308d9a2867427479d277365b1617e48ad09696fa7dfcdf59"},
-    {file = "regex-2021.10.8-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:951be934dc25d8779d92b530e922de44dda3c82a509cdb5d619f3a0b1491fafa"},
-    {file = "regex-2021.10.8-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f125fce0a0ae4fd5c3388d369d7a7d78f185f904c90dd235f7ecf8fe13fa741"},
-    {file = "regex-2021.10.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f199419a81c1016e0560c39773c12f0bd924c37715bffc64b97140d2c314354"},
-    {file = "regex-2021.10.8-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:09e1031e2059abd91177c302da392a7b6859ceda038be9e015b522a182c89e4f"},
-    {file = "regex-2021.10.8-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9c070d5895ac6aeb665bd3cd79f673775caf8d33a0b569e98ac434617ecea57d"},
-    {file = "regex-2021.10.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:176796cb7f82a7098b0c436d6daac82f57b9101bb17b8e8119c36eecf06a60a3"},
-    {file = "regex-2021.10.8-cp38-cp38-win32.whl", hash = "sha256:5e5796d2f36d3c48875514c5cd9e4325a1ca172fc6c78b469faa8ddd3d770593"},
-    {file = "regex-2021.10.8-cp38-cp38-win_amd64.whl", hash = "sha256:e4204708fa116dd03436a337e8e84261bc8051d058221ec63535c9403a1582a1"},
-    {file = "regex-2021.10.8-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6dcf53d35850ce938b4f044a43b33015ebde292840cef3af2c8eb4c860730fff"},
-    {file = "regex-2021.10.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b8b6ee6555b6fbae578f1468b3f685cdfe7940a65675611365a7ea1f8d724991"},
-    {file = "regex-2021.10.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e2ec1c106d3f754444abf63b31e5c4f9b5d272272a491fa4320475aba9e8157c"},
-    {file = "regex-2021.10.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:973499dac63625a5ef9dfa4c791aa33a502ddb7615d992bdc89cf2cc2285daa3"},
-    {file = "regex-2021.10.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88dc3c1acd3f0ecfde5f95c32fcb9beda709dbdf5012acdcf66acbc4794468eb"},
-    {file = "regex-2021.10.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4786dae85c1f0624ac77cb3813ed99267c9adb72e59fdc7297e1cf4d6036d493"},
-    {file = "regex-2021.10.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fe6ce4f3d3c48f9f402da1ceb571548133d3322003ce01b20d960a82251695d2"},
-    {file = "regex-2021.10.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9e3e2cea8f1993f476a6833ef157f5d9e8c75a59a8d8b0395a9a6887a097243b"},
-    {file = "regex-2021.10.8-cp39-cp39-win32.whl", hash = "sha256:82cfb97a36b1a53de32b642482c6c46b6ce80803854445e19bc49993655ebf3b"},
-    {file = "regex-2021.10.8-cp39-cp39-win_amd64.whl", hash = "sha256:b04e512eb628ea82ed86eb31c0f7fc6842b46bf2601b66b1356a7008327f7700"},
-    {file = "regex-2021.10.8.tar.gz", hash = "sha256:26895d7c9bbda5c52b3635ce5991caa90fbb1ddfac9c9ff1c7ce505e2282fb2a"},
-]
 requests = [
     {file = "requests-2.26.0-py2.py3-none-any.whl", hash = "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24"},
     {file = "requests-2.26.0.tar.gz", hash = "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"},
@@ -1132,24 +1091,24 @@ simplejson = [
     {file = "simplejson-3.11.1.win32-py3.5.exe", hash = "sha256:c76d55d78dc8b06c96fd08c6cc5e2b0b650799627d3f9ca4ad23f40db72d5f6d"},
 ]
 singer-sdk = [
-    {file = "singer-sdk-0.3.11.tar.gz", hash = "sha256:60e72fa86cd31e3be255d30f9751ba050114e3007f234f9b82212e6736643dd9"},
-    {file = "singer_sdk-0.3.11-py3-none-any.whl", hash = "sha256:9e4c0ece54708a4a4f535d966b2528361467c7c9780a98d58623cb1b31e86b05"},
+    {file = "singer-sdk-0.3.17.tar.gz", hash = "sha256:74ac79df1d410700d740fc1c648eae49830c2147d66166492e2adedf2378a3f0"},
+    {file = "singer_sdk-0.3.17-py3-none-any.whl", hash = "sha256:314801ffac1e69a420e436f27a20e384cddc8d57866854d4a0e4e48b2d5f2849"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 snowballstemmer = [
-    {file = "snowballstemmer-2.1.0-py2.py3-none-any.whl", hash = "sha256:b51b447bea85f9968c13b650126a888aabd4cb4463fca868ec596826325dedc2"},
-    {file = "snowballstemmer-2.1.0.tar.gz", hash = "sha256:e997baa4f2e9139951b6f4c631bad912dfd3c792467e2f03d7239464af90e914"},
+    {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
+    {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tomli = [
-    {file = "tomli-1.2.1-py3-none-any.whl", hash = "sha256:8dd0e9524d6f386271a36b41dbf6c57d8e32fd96fd22b6584679dc569d20899f"},
-    {file = "tomli-1.2.1.tar.gz", hash = "sha256:a5b75cb6f3968abb47af1b40c1819dc519ea82bcc065776a866e8d74c5ca9442"},
+    {file = "tomli-1.2.3-py3-none-any.whl", hash = "sha256:e3069e4be3ead9668e21cb9b074cd948f7b3113fd9c8bba083f48247aab8b11c"},
+    {file = "tomli-1.2.3.tar.gz", hash = "sha256:05b6166bff487dc068d322585c7ea4ef78deed501cc124060e0f238e89a9231f"},
 ]
 tox = [
     {file = "tox-3.24.4-py2.py3-none-any.whl", hash = "sha256:5e274227a53dc9ef856767c21867377ba395992549f02ce55eb549f9fb9a8d10"},
@@ -1188,21 +1147,20 @@ typed-ast = [
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 types-requests = [
-    {file = "types-requests-2.25.11.tar.gz", hash = "sha256:b279284e51f668e38ee12d9665e4d789089f532dc2a0be4a1508ca0efd98ba9e"},
-    {file = "types_requests-2.25.11-py3-none-any.whl", hash = "sha256:ba1d108d512e294b6080c37f6ae7cb2a2abf527560e2b671d1786c1fc46b541a"},
+    {file = "types-requests-2.26.2.tar.gz", hash = "sha256:0e22d9cdeff4c3eb068eb883d59b127c98d80525f3d0412a1c4499c6ae1f711e"},
+    {file = "types_requests-2.26.2-py3-none-any.whl", hash = "sha256:fabe1acc784708ac798ced6373568465b93642c8aa1ebd33e2921b60d4e7aa29"},
 ]
 typing-extensions = [
-    {file = "typing_extensions-3.10.0.2-py2-none-any.whl", hash = "sha256:d8226d10bc02a29bcc81df19a26e56a9647f8b0a6d4a83924139f4a8b01f17b7"},
-    {file = "typing_extensions-3.10.0.2-py3-none-any.whl", hash = "sha256:f1d25edafde516b146ecd0613dabcc61409817af4766fbbcfb8d1ad4ec441a34"},
-    {file = "typing_extensions-3.10.0.2.tar.gz", hash = "sha256:49f75d16ff11f1cd258e1b988ccff82a3ca5570217d7ad8c5f48205dd99a677e"},
+    {file = "typing_extensions-4.0.1-py3-none-any.whl", hash = "sha256:7f001e5ac290a0c0401508864c7ec868be4e701886d5b573a9528ed3973d9d3b"},
+    {file = "typing_extensions-4.0.1.tar.gz", hash = "sha256:4ca091dea149f945ec56afb48dae714f21e8692ef22a395223bcd328961b6a0e"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.7-py2.py3-none-any.whl", hash = "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"},
     {file = "urllib3-1.26.7.tar.gz", hash = "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.8.1-py2.py3-none-any.whl", hash = "sha256:10062e34c204b5e4ec5f62e6ef2473f8ba76513a9a617e873f1f8fb4a519d300"},
-    {file = "virtualenv-20.8.1.tar.gz", hash = "sha256:bcc17f0b3a29670dd777d6f0755a4c04f28815395bca279cdcb213b97199a6b8"},
+    {file = "virtualenv-20.10.0-py2.py3-none-any.whl", hash = "sha256:4b02e52a624336eece99c96e3ab7111f469c24ba226a53ec474e8e787b365814"},
+    {file = "virtualenv-20.10.0.tar.gz", hash = "sha256:576d05b46eace16a9c348085f7d0dc8ef28713a2cabaa1cf0aea41e8f12c9218"},
 ]
 zipp = [
     {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [tool.poetry]
 name = "tap-rest-api-msdk"
-version = "0.0.6"
+version = "0.1.0"
 description = "`tap-rest-api-msdk` is a Singer tap for REST APIs, built with the Meltano SDK for Singer Taps."
-authors = ["Josh Lloyd"]
+authors = ["Josh Lloyd", "Fred Reimer"]
 keywords = [
     "ELT",
     "rest-api-msdk",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-rest-api-msdk"
-version = "0.1.1"
+version = "0.2.0"
 description = "`tap-rest-api-msdk` is a Singer tap for REST APIs, built with the Meltano SDK for Singer Taps."
 authors = ["Josh Lloyd", "Fred Reimer"]
 keywords = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-rest-api-msdk"
-version = "0.1.0"
+version = "0.1.1"
 description = "`tap-rest-api-msdk` is a Singer tap for REST APIs, built with the Meltano SDK for Singer Taps."
 authors = ["Josh Lloyd", "Fred Reimer"]
 keywords = [

--- a/tap_rest_api_msdk/client.py
+++ b/tap_rest_api_msdk/client.py
@@ -9,8 +9,7 @@ SCHEMAS_DIR = Path(__file__).parent / Path("./schemas")
 
 class RestApiStream(RESTStream):
     """rest-api stream class."""
-
     @property
     def url_base(self) -> str:
         """Return the API URL root, configurable via tap settings."""
-        return self.config["api_url"]
+        return self.api_url

--- a/tap_rest_api_msdk/streams.py
+++ b/tap_rest_api_msdk/streams.py
@@ -79,7 +79,7 @@ class DynamicStream(RestApiStream):
         pagination = response.json().get('pagination', {})
         if pagination and all(x in pagination for x in ['offset', 'limit', 'total']):
             next_page_token = pagination['offset'] + pagination['limit']
-            if next_page_token <= pagination['total']:
+            if next_page_token < pagination['total']:
                 return next_page_token
         return None
 

--- a/tap_rest_api_msdk/streams.py
+++ b/tap_rest_api_msdk/streams.py
@@ -11,19 +11,23 @@ from tap_rest_api_msdk.utils import flatten_json
 
 class DynamicStream(RestApiStream):
     """Define custom stream."""
-    def __init__(self,
-                 tap,
-                 name,
-                 path=None,
-                 params=None,
-                 headers=None,
-                 primary_keys=None,
-                 replication_key=None,
-                 except_keys=None,
-                 records_path=None,
-                 next_page_token_path=None,
-                 schema=None,
-                 ):
+    def __init__(
+        self,
+        tap,
+        name,
+        path=None,
+        params=None,
+        headers=None,
+        primary_keys=None,
+        replication_key=None,
+        except_keys=None,
+        records_path=None,
+        next_page_token_path=None,
+        schema=None,
+        pagination_request_style='default',
+        pagination_response_style='default',
+        pagination_page_size=None,
+    ):
         super().__init__(tap=tap, name=tap.name, schema=schema)
 
         if primary_keys is None:
@@ -38,6 +42,12 @@ class DynamicStream(RestApiStream):
         self.except_keys = except_keys
         self.records_path = records_path
         self.next_page_token_jsonpath = next_page_token_path  # Or override `get_next_page_token`.
+        self.pagination_page_size = pagination_page_size
+        get_url_params_styles = {'style1': self._get_url_params_style1}
+        self.get_url_params = get_url_params_styles.get(pagination_response_style, self._get_url_params_default)
+        get_next_page_token_styles = {'style1': self._get_next_page_token_style1}
+        self.get_next_page_token = get_next_page_token_styles.get(pagination_response_style,
+                                                                  self._get_next_page_token_default)
 
     @property
     def http_headers(self) -> dict:
@@ -54,12 +64,10 @@ class DynamicStream(RestApiStream):
 
         return headers
 
-    def get_next_page_token(self, response: requests.Response, previous_token: Optional[Any]) -> Optional[Any]:
+    def _get_next_page_token_default(self, response: requests.Response, previous_token: Optional[Any]) -> Optional[Any]:
         """Return a token for identifying next page or None if no more pages."""
         if self.next_page_token_jsonpath:
-            all_matches = extract_jsonpath(
-                self.next_page_token_jsonpath, response.json()
-            )
+            all_matches = extract_jsonpath("self.next_page_token_jsonpath", response.json())
             first_match = next(iter(all_matches), None)
             next_page_token = first_match
         else:
@@ -67,7 +75,15 @@ class DynamicStream(RestApiStream):
 
         return next_page_token
 
-    def get_url_params(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
+    def _get_next_page_token_style1(self, response: requests.Response, previous_token: Optional[Any]) -> Optional[Any]:
+        pagination = response.json().get('pagination', {})
+        if pagination and all(x in pagination for x in ['offset', 'limit', 'total']):
+            next_page_token = pagination['offset'] + pagination['limit']
+            if next_page_token <= pagination['total']:
+                return next_page_token
+        return None
+
+    def _get_url_params_default(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
         """Return a dictionary of values to be used in URL parameterization."""
         params: dict = {}
         if self.params:
@@ -75,6 +91,21 @@ class DynamicStream(RestApiStream):
                 params[k] = v
         if next_page_token:
             params["page"] = next_page_token
+        if self.replication_key:
+            params["sort"] = "asc"
+            params["order_by"] = self.replication_key
+        return params
+
+    def _get_url_params_style1(self, context: Optional[dict], next_page_token: Optional[Any]) -> Dict[str, Any]:
+        """Return a dictionary of values to be used in URL parameterization."""
+        params: dict = {}
+        if self.params:
+            for k, v in self.params.items():
+                params[k] = v
+        if next_page_token:
+            params["offset"] = next_page_token
+        if self.pagination_page_size is not None:
+            params["limit"] = self.pagination_page_size
         if self.replication_key:
             params["sort"] = "asc"
             params["order_by"] = self.replication_key

--- a/tap_rest_api_msdk/streams.py
+++ b/tap_rest_api_msdk/streams.py
@@ -15,6 +15,7 @@ class DynamicStream(RestApiStream):
         self,
         tap,
         name,
+        api_url=None,
         path=None,
         params=None,
         headers=None,
@@ -34,6 +35,7 @@ class DynamicStream(RestApiStream):
             primary_keys = []
 
         self.name = name
+        self.api_url = api_url
         self.path = path
         self.params = params
         self.headers = headers

--- a/tap_rest_api_msdk/tap.py
+++ b/tap_rest_api_msdk/tap.py
@@ -1,7 +1,8 @@
 """rest-api tap class."""
-
+import copy
 import requests
-from typing import List
+from pathlib import Path, PurePath
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, Union, cast
 
 from genson import SchemaBuilder
 from singer_sdk import Tap, Stream
@@ -16,113 +17,176 @@ class TapRestApiMsdk(Tap):
     """rest-api tap class."""
     name = "tap-rest-api-msdk"
 
-    config_jsonschema = th.PropertiesList(
-        th.Property("api_url", th.StringType, required=True, description="the base url/endpoint for the desired api"),
-        # th.Property("auth_method", th.StringType, default='no_auth', required=False),
-        # th.Property("auth_token", th.StringType, required=False),
-        th.Property('name', th.StringType, required=True, description="name of the stream"),
-        th.Property('path',
-                    th.StringType,
-                    default="",
-                    required=False,
-                    description="the path appeneded to the `api_url`."),
-        th.Property('params',
-                    th.ObjectType(),
-                    required=False,
-                    description="an object of objects that provide the `params` in a `requests.get` method."),
-        th.Property('headers',
-                    th.ObjectType(),
-                    required=False,
-                    description="an object of headers to pass into the api calls."),
-        th.Property("records_path",
-                    th.StringType,
-                    default="$[*]",
-                    required=False,
-                    description="a jsonpath string representing the path in the requests response that contains the "
-                    "records to process. Defaults to `$[*]`."),
-        th.Property("next_page_token_path",
-                    th.StringType,
-                    default="$.next_page",
-                    required=False,
-                    description="a jsonpath string representing the path to the 'next page' token. "
-                    "Defaults to `$.next_page`"),
-        th.Property("pagination_request_style",
-                    th.StringType,
-                    default="default",
-                    required=False,
-                    description="the pagination style to use for requests. "
-                    "Defaults to `default`"),
-        th.Property("pagination_response_style",
-                    th.StringType,
-                    default="default",
-                    required=False,
-                    description="the pagination style to use for response. "
-                    "Defaults to `default`"),
-        th.Property("pagination_page_size",
-                    th.IntegerType,
-                    default=None,
-                    required=False,
-                    description="the size of each page in records. "
-                    "Defaults to None"),
-        th.Property('primary_keys',
-                    th.ArrayType(th.StringType),
-                    required=True,
-                    description="a list of the json keys of the primary key for the stream."),
-        th.Property('replication_key',
-                    th.StringType,
-                    required=False,
-                    description="the json key of the replication key. Note that this should be an incrementing "
-                    "integer or datetime object."),
-        th.Property('except_keys',
-                    th.ArrayType(th.StringType),
-                    default=[],
-                    required=False,
-                    description="This tap automatically flattens the entire json structure and builds keys based on "
-                    "the corresponding paths.; Keys, whether composite or otherwise, listed in this "
-                    "dictionary will not be recursively flattened, but instead their values will be; "
-                    "turned into a json string and processed in that format. This is also automatically "
-                    "done for any lists within the records; therefore,; records are not duplicated for "
-                    "each item in lists."),
-        th.Property('num_inference_records',
-                    th.NumberType,
-                    default=50,
-                    required=False,
-                    description="number of records used to infer the stream's schema. Defaults to 50."),
-    ).to_dict()
+    def __init__(self, **kwargs) -> None:
+        stream_schema = th.ObjectType(
+            th.Property("api_url",
+                        th.StringType,
+                        required=False,
+                        description="the base url/endpoint for the desired api"),
+            # th.Property("auth_method", th.StringType, default='no_auth', required=False),
+            # th.Property("auth_token", th.StringType, required=False),
+            th.Property('name', th.StringType, required=False, description="name of the stream"),
+            th.Property('path',
+                        th.StringType,
+                        default="",
+                        required=False,
+                        description="the path appeneded to the `api_url`."),
+            th.Property('params',
+                        th.ObjectType(),
+                        required=False,
+                        description="an object of objects that provide the `params` in a `requests.get` method."),
+            th.Property(
+                "records_path",
+                th.StringType,
+                default="$[*]",
+                required=False,
+                description="a jsonpath string representing the path in the requests response that contains the "
+                "records to process. Defaults to `$[*]`."),
+            th.Property("next_page_token_path",
+                        th.StringType,
+                        default="$.next_page",
+                        required=False,
+                        description="a jsonpath string representing the path to the 'next page' token. "
+                        "Defaults to `$.next_page`"),
+            th.Property("pagination_request_style",
+                        th.StringType,
+                        default="default",
+                        required=False,
+                        description="the pagination style to use for requests. "
+                        "Defaults to `default`"),
+            th.Property("pagination_response_style",
+                        th.StringType,
+                        default="default",
+                        required=False,
+                        description="the pagination style to use for response. "
+                        "Defaults to `default`"),
+            th.Property("pagination_page_size",
+                        th.IntegerType,
+                        default=None,
+                        required=False,
+                        description="the size of each page in records. "
+                        "Defaults to None"),
+            th.Property('primary_keys',
+                        th.ArrayType(th.StringType),
+                        required=False,
+                        description="a list of the json keys of the primary key for the stream."),
+            th.Property('replication_key',
+                        th.StringType,
+                        required=False,
+                        description="the json key of the replication key. Note that this should be an incrementing "
+                        "integer or datetime object."),
+            th.Property(
+                'except_keys',
+                th.ArrayType(th.StringType),
+                default=[],
+                required=False,
+                description="This tap automatically flattens the entire json structure and builds keys based on "
+                "the corresponding paths.; Keys, whether composite or otherwise, listed in this "
+                "dictionary will not be recursively flattened, but instead their values will be; "
+                "turned into a json string and processed in that format. This is also automatically "
+                "done for any lists within the records; therefore,; records are not duplicated for "
+                "each item in lists."),
+            th.Property('num_inference_records',
+                        th.NumberType,
+                        default=50,
+                        required=False,
+                        description="number of records used to infer the stream's schema. Defaults to 50."),
+        )
+        # Make a copy of the stream schema ObjectType as a ProperiesList (but different list)
+        schema = th.PropertiesList()
+        schema.wrapped = copy.copy(stream_schema.wrapped)
+        # Add in headers for legacy single-stream configuration
+        schema.append(
+            th.Property('headers',
+                        th.ObjectType(),
+                        required=False,
+                        description="an object of headers to pass into the api calls."), )
+        # Add property for multiple streams
+        schema.append(
+            th.Property("streams",
+                        th.ArrayType(stream_schema),
+                        default=None,
+                        required=False,
+                        description="Array of objects that describe multiple streams"))
+        # Add property for multiple streams authentication
+        # This usually has a different source than rest of configuration as it contains
+        # sensitive information (API credentials) and should not be checked into VCS as
+        # the rest of the configuration for a data pipeline typically is.
+        schema.append(
+            th.Property("streams_auth",
+                        th.ObjectType(),
+                        default=[],
+                        required=False,
+                        description="List of objects with a name and header values for corresponding stream names"))
+        self.__class__.config_jsonschema = schema.to_dict()
+        super().__init__(**kwargs)
 
     def discover_streams(self) -> List[Stream]:
         """Return a list of discovered streams."""
-        return [
-            DynamicStream(
-                tap=self,
-                name=self.config['name'],
-                path=self.config['path'],
-                params=self.config.get('params'),
-                headers=self.config.get('headers'),
-                records_path=self.config['records_path'],
-                next_page_token_path=self.config['next_page_token_path'],
-                primary_keys=self.config['primary_keys'],
-                replication_key=self.config.get('replication_key'),
-                except_keys=self.config.get('except_keys'),
-                schema=self.get_schema(
-                    self.config['records_path'],
-                    self.config.get('except_keys'),
-                    self.config.get('num_inference_records'),
-                    self.config['path'],
-                    self.config.get('params'),
-                    self.config.get('headers'),
-                ),
-                pagination_request_style=self.config.get('pagination_request_style', 'default'),
-                pagination_response_style=self.config.get('pagination_response_style', 'default'),
-                pagination_page_size=self.config.get('pagination_page_size'),
-            )
-        ]
+        if len(self.config.get('streams', [])) == 0:
+            return [
+                DynamicStream(
+                    tap=self,
+                    name=self.config['name'],
+                    api_url=self.config['api_url'],
+                    path=self.config['path'],
+                    params=self.config.get('params'),
+                    headers=self.config.get('headers'),
+                    records_path=self.config['records_path'],
+                    next_page_token_path=self.config['next_page_token_path'],
+                    primary_keys=self.config['primary_keys'],
+                    replication_key=self.config.get('replication_key'),
+                    except_keys=self.config.get('except_keys'),
+                    schema=self.get_schema(
+                        self.config['api_url'],
+                        self.config['records_path'],
+                        self.config.get('except_keys'),
+                        self.config.get('num_inference_records'),
+                        self.config['path'],
+                        self.config.get('params'),
+                        self.config.get('headers'),
+                    ),
+                    pagination_request_style=self.config.get('pagination_request_style', 'default'),
+                    pagination_response_style=self.config.get('pagination_response_style', 'default'),
+                    pagination_page_size=self.config.get('pagination_page_size'),
+                )
+            ]
+        streams = []
+        for stream in self.config['streams']:
+            headers = self.config.get('streams_auth', {}).get(stream['name'], {}).get('headers')
+            streams.append(
+                DynamicStream(
+                    tap=self,
+                    name=stream['name'],
+                    api_url=stream['api_url'],
+                    path=stream['path'],
+                    params=stream.get('params'),
+                    headers=headers,
+                    records_path=stream['records_path'],
+                    next_page_token_path=stream['next_page_token_path'],
+                    primary_keys=stream['primary_keys'],
+                    replication_key=stream.get('replication_key'),
+                    except_keys=stream.get('except_keys'),
+                    schema=self.get_schema(
+                        stream['api_url'],
+                        stream['records_path'],
+                        stream.get('except_keys'),
+                        stream.get('num_inference_records'),
+                        stream['path'],
+                        stream.get('params'),
+                        headers,
+                    ),
+                    pagination_request_style=stream.get('pagination_request_style', 'default'),
+                    pagination_response_style=stream.get('pagination_response_style', 'default'),
+                    pagination_page_size=stream.get('pagination_page_size'),
+                ))
+        return streams
 
-    def get_schema(self, records_path, except_keys, inference_records, path, params, headers) -> dict:
+    def get_schema(self, api_url, records_path, except_keys, inference_records, path, params, headers) -> dict:
         """Infer schema from the first records returned by api. Creates a Stream object."""
 
         # todo: this request format is not very robust
-        r = requests.get(self.config['api_url'] + path, params=params, headers=headers)
+        r = requests.get(api_url + path, params=params, headers=headers)
         if r.ok:
             records = extract_jsonpath(records_path, input=r.json())
         else:

--- a/tap_rest_api_msdk/tap.py
+++ b/tap_rest_api_msdk/tap.py
@@ -17,37 +17,76 @@ class TapRestApiMsdk(Tap):
     name = "tap-rest-api-msdk"
 
     config_jsonschema = th.PropertiesList(
-        th.Property("api_url", th.StringType, required=True,
-                    description="the base url/endpoint for the desired api"),
+        th.Property("api_url", th.StringType, required=True, description="the base url/endpoint for the desired api"),
         # th.Property("auth_method", th.StringType, default='no_auth', required=False),
         # th.Property("auth_token", th.StringType, required=False),
-        th.Property('name', th.StringType, required=True,
-                    description="name of the stream"),
-        th.Property('path', th.StringType, default="", required=False,
+        th.Property('name', th.StringType, required=True, description="name of the stream"),
+        th.Property('path',
+                    th.StringType,
+                    default="",
+                    required=False,
                     description="the path appeneded to the `api_url`."),
-        th.Property('params', th.ObjectType(), required=False,
+        th.Property('params',
+                    th.ObjectType(),
+                    required=False,
                     description="an object of objects that provide the `params` in a `requests.get` method."),
-        th.Property('headers', th.ObjectType(), required=False,
+        th.Property('headers',
+                    th.ObjectType(),
+                    required=False,
                     description="an object of headers to pass into the api calls."),
-        th.Property("records_path", th.StringType, default="$[*]", required=False,
+        th.Property("records_path",
+                    th.StringType,
+                    default="$[*]",
+                    required=False,
                     description="a jsonpath string representing the path in the requests response that contains the "
-                                "records to process. Defaults to `$[*]`."),
-        th.Property("next_page_token_path", th.StringType, default="$.next_page", required=False,
+                    "records to process. Defaults to `$[*]`."),
+        th.Property("next_page_token_path",
+                    th.StringType,
+                    default="$.next_page",
+                    required=False,
                     description="a jsonpath string representing the path to the 'next page' token. "
-                                "Defaults to `$.next_page`"),
-        th.Property('primary_keys', th.ArrayType(th.StringType), required=True,
+                    "Defaults to `$.next_page`"),
+        th.Property("pagination_request_style",
+                    th.StringType,
+                    default="default",
+                    required=False,
+                    description="the pagination style to use for requests. "
+                    "Defaults to `default`"),
+        th.Property("pagination_response_style",
+                    th.StringType,
+                    default="default",
+                    required=False,
+                    description="the pagination style to use for response. "
+                    "Defaults to `default`"),
+        th.Property("pagination_page_size",
+                    th.IntegerType,
+                    default=None,
+                    required=False,
+                    description="the size of each page in records. "
+                    "Defaults to None"),
+        th.Property('primary_keys',
+                    th.ArrayType(th.StringType),
+                    required=True,
                     description="a list of the json keys of the primary key for the stream."),
-        th.Property('replication_key', th.StringType, required=False,
+        th.Property('replication_key',
+                    th.StringType,
+                    required=False,
                     description="the json key of the replication key. Note that this should be an incrementing "
-                                "integer or datetime object."),
-        th.Property('except_keys', th.ArrayType(th.StringType), default=[], required=False,
+                    "integer or datetime object."),
+        th.Property('except_keys',
+                    th.ArrayType(th.StringType),
+                    default=[],
+                    required=False,
                     description="This tap automatically flattens the entire json structure and builds keys based on "
-                                "the corresponding paths.; Keys, whether composite or otherwise, listed in this "
-                                "dictionary will not be recursively flattened, but instead their values will be; "
-                                "turned into a json string and processed in that format. This is also automatically "
-                                "done for any lists within the records; therefore,; records are not duplicated for "
-                                "each item in lists."),
-        th.Property('num_inference_records', th.NumberType, default=50, required=False,
+                    "the corresponding paths.; Keys, whether composite or otherwise, listed in this "
+                    "dictionary will not be recursively flattened, but instead their values will be; "
+                    "turned into a json string and processed in that format. This is also automatically "
+                    "done for any lists within the records; therefore,; records are not duplicated for "
+                    "each item in lists."),
+        th.Property('num_inference_records',
+                    th.NumberType,
+                    default=50,
+                    required=False,
                     description="number of records used to infer the stream's schema. Defaults to 50."),
     ).to_dict()
 
@@ -72,7 +111,10 @@ class TapRestApiMsdk(Tap):
                     self.config['path'],
                     self.config.get('params'),
                     self.config.get('headers'),
-                )
+                ),
+                pagination_request_style=self.config.get('pagination_request_style', 'default'),
+                pagination_response_style=self.config.get('pagination_response_style', 'default'),
+                pagination_page_size=self.config.get('pagination_page_size'),
             )
         ]
 


### PR DESCRIPTION
This incorporates the last PR, but also resolves issue #3 

The old-style parameters are supported, buy you can now specify multiple streams in the configuration.  Simply create an array names streams with a list of objects that have the same content as the original parameters.  Example in the meltano.yml file.  I broke out the headers, and in the future other authentication information should be kept separate, into a streams_auth objects.  That object has property names matching the names of the streams, and content of whatever is needed for authentication.  For now, only a headers property is used.
