### PR TITLE
enabled capability of added more than one stream per api url. Also en…

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,17 +66,37 @@ tap is available by running:
 tap-rest-api-msdk --about
 ```
 
-Config Options:
+#### Top-level config options. 
+Parameters that appear at the stream-level will overwrite their top-level 
+counterparts except where noted in the stream-level params. Otherwise, the values
+provided at the top-level will be the default values for each stream.:
 - `api_url`: required: the base url/endpoint for the desired api.
-- `name`: required: name of the stream.
-- `path`: optional: the path appeneded to the `api_url`.
-- `params`: optional: an object of objects that provide the `params` in a `requests.get` method.
-- `headers`: optional: an object of headers to pass into the api calls.
-- `records_path`: optional: a jsonpath string representing the path in the requests response that contains the records to process. Defaults to `$[*]`.
 - `pagination_request_style`: optional: style for requesting pagination, defaults to `default`, see Pagination below.
 - `pagination_response_style`: optional: style of pagination results, defaults to `default`, see Pagination below.
 - `pagination_page_size`: optional: limit for size of page, defaults to None.
 - `next_page_token_path`: optional: a jsonpath string representing the path to the "next page" token. Defaults to `$.next_page`.
+- `streams`: required: a list of objects that contain the configuration of each stream. See stream-level params below.
+- `path`: optional: see stream-level params below.
+- `params`: optional: see stream-level params below.
+- `headers`: optional: see stream-level params below.
+- `records_path`: optional: see stream-level params below.
+- `primary_keys`: optional: see stream-level params below.
+- `replication_key`: optional: see stream-level params below.
+- `except_keys`: optional: see stream-level params below.
+- `num_inference_keys`: optional:  see stream-level params below.
+
+#### Stream level config options. 
+Parameters that appear at the stream-level
+will overwrite their top-level counterparts except where noted below:
+- `name`: required: name of the stream.
+- `path`: optional: the path appeneded to the `api_url`.
+- `params`: optional: an object of objects that provide the `params` in a `requests.get` method.
+  Stream level params will be merged with top-level params with stream level params overwriting 
+  top-level params with the same key.
+- `headers`: optional: an object of headers to pass into the api calls. Stream level
+  headers will be merged with top-level params with stream level params overwriting 
+  top-level params with the same key
+- `records_path`: optional: a jsonpath string representing the path in the requests response that contains the records to process. Defaults to `$[*]`.
 - `primary_keys`: required: a list of the json keys of the primary key for the stream.
 - `replication_key`: optional: the json key of the replication key. Note that this should be an incrementing integer or datetime object.
 - `except_keys`: This tap automatically flattens the entire json structure and builds keys based on the corresponding paths.

--- a/meltano.yml
+++ b/meltano.yml
@@ -11,32 +11,47 @@ plugins:
         - discover
       settings:
         - name: api_url
-        - name: name
-        - name: path
-        - name: params
-        - name: headers
-        - name: records_path
+          kind: string
         - name: next_page_token_path
+          kind: string
         - name: pagination_request_style
+          kind: string
         - name: pagination_response_style
+          kind: string
         - name: pagination_page_size
+          kind: integer
+        - name: streams
+          kind: array
+        - name: path
+          kind: string
+        - name: params
+          kind: object
+        - name: headers
+          kind: object
+        - name: records_path
+          kind: string
         - name: primary_keys
+          kind: array
         - name: replication_key
+          kind: string
         - name: except_keys
+          kind: array
         - name: num_inference_records
+          kind: integer
       config:
-        name: us_earthquakes
         api_url: https://earthquake.usgs.gov/fdsnws
-        path: /event/1/query
-        params:
-          format: geojson
-          starttime: "2014-01-01"
-          endtime: "2014-01-02"
-          minmagnitude: 1
-        primary_keys:
-          - id
         records_path: "$.features[*]"
-        num_inference_records: 100
+        streams:
+          - name: us_earthquakes
+            path: /event/1/query
+            params:
+              format: geojson
+              starttime: "2014-01-01"
+              endtime: "2014-01-02"
+              minmagnitude: 1
+            primary_keys:
+              - id
+            num_inference_records: 100
       select:
         - '*.*'
   loaders:

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -17,13 +17,15 @@ def config(extras: dict = None) -> dict:
     """
     contents = {
         "api_url": "https://example.com",
-        "name": "stream_name",
-        "auth_method": "no_auth",
-        "auth_token": "",
-        "path": "/path_test",
-        "primary_keys": ["key1", "key2"],
-        "replication_key": "key3",
-        "records_path": "$.records[*]",
+        "streams": [
+            {
+                "name": "stream_name",
+                "path": "/path_test",
+                "primary_keys": ["key1", "key2"],
+                "replication_key": "key3",
+                "records_path": "$.records[*]",
+            }
+        ],
     }
     if extras:
         for k, v in extras.items():
@@ -71,6 +73,7 @@ def url_path(path: str = "/path_test") -> str:
 
 def setup_api(
     requests_mock: Any,
+    url_path: str = url_path(),
     json_extras: dict = None,
     headers_extras: dict = None,
     matcher: Any = None,
@@ -79,6 +82,7 @@ def setup_api(
 
     Args:
         requests_mock: mock object for requests.
+        url_path: url to mack for mocking.
         json_extras: extra items to add to the response's results.
         headers_extras: extra items to add to the API call's header.
         matcher: a function that checks a request's input for the appropriate
@@ -93,12 +97,12 @@ def setup_api(
             headers_resp[k] = v
 
     requests_mock.get(
-        url_path(),
+        url_path,
         headers=headers_resp,
         json=json_resp(json_extras),
         additional_matcher=matcher,
     )
-    return requests.Session().get(url_path())
+    return requests.Session().get(url_path)
 
 
 def test_get_next_page_token_default_jsonpath(requests_mock: Any):
@@ -110,10 +114,7 @@ def test_get_next_page_token_default_jsonpath(requests_mock: Any):
     stream0 = TapRestApiMsdk(config=config(), parse_env_config=True).discover_streams()[
         0
     ]
-    assert (
-        stream0._get_next_page_token_default(resp, "previous_token_example")
-        == "next_page_token_example"
-    )
+    assert stream0._get_next_page_token_default(resp, "t") == "next_page_token_example"
     assert stream0.get_next_page_token == stream0._get_next_page_token_default
 
 

--- a/tests/test_tap.py
+++ b/tests/test_tap.py
@@ -22,3 +22,30 @@ def test_schema_inference(requests_mock):
             "key3": {"type": "string"},
         },
     }
+
+
+def test_multiple_streams(requests_mock):
+    setup_api(requests_mock)
+    setup_api(requests_mock, url_path="https://example.com/path_test2")
+    configs = config({"records_path": "$.records[*]"})
+    configs["streams"].append(
+        {
+            "name": "stream_name2",
+            "path": "/path_test2",
+            "primary_keys": ["key4", "key5"],
+            "replication_key": "key6",
+        }
+    )
+
+    streams = TapRestApiMsdk(config=configs, parse_env_config=True).discover_streams()
+
+    assert streams[0].name == "stream_name"
+    assert streams[0].records_path == "$.records[*]"
+    assert streams[0].path == "/path_test"
+    assert streams[0].primary_keys == ["key1", "key2"]
+    assert streams[0].replication_key == "key3"
+    assert streams[1].name == "stream_name2"
+    assert streams[1].records_path == "$.records[*]"
+    assert streams[1].path == "/path_test2"
+    assert streams[1].primary_keys == ["key4", "key5"]
+    assert streams[1].replication_key == "key6"


### PR DESCRIPTION
Also enabled common parameters among them.

See the readme for additional details on how this works. There are some parameters than can only be defined at the top level (i.e., pagination and api_url) while most other parameters are defined on a stream by stream basis using top level versions of those parameters to be defaults or common settings for all of the streams.

Please note that this can make it difficult to introduce env variable overrides to the yml settings in Meltano.

Addresses issues #3 and  #9

This introduces a breaking change because the `name` parameter is now forced down to the stream-level params.

Big thanks to @freimer for his PRs #4 and #10 which helped to pave the way for this PR.