### PR TITLE
added ability to provide schema in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ provided at the top-level will be the default values for each stream.:
 Parameters that appear at the stream-level
 will overwrite their top-level counterparts except where noted below:
 - `name`: required: name of the stream.
-- `path`: optional: the path appeneded to the `api_url`.
+- `path`: optional: the path appended to the `api_url`.
 - `params`: optional: an object of objects that provide the `params` in a `requests.get` method.
   Stream level params will be merged with top-level params with stream level params overwriting 
   top-level params with the same key.
@@ -104,6 +104,9 @@ will overwrite their top-level counterparts except where noted below:
   turned into a json string and processed in that format. This is also automatically done for any lists within the records; therefore,
   records are not duplicated for each item in lists.
 - `num_inference_keys`: optional: number of records used to infer the stream's schema. Defaults to 50.
+- `scheam`: optional: A valid Singer schema or a path-like string that provides
+  the path to a `.json` file that contains a valid Singer schema. If provided, 
+  the schema will not be inferred from the results of an api call.
 
 ## Pagination
 Pagination is a complex topic as there is no real single standard, and many different implementations.  Unless options are provided, both the request and results stype default to the `default`, which is the pagination style originally implemented.

--- a/tests/schema.json
+++ b/tests/schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "type": "object",
+  "properties": {
+    "key1": {
+      "type": "string"
+    },
+    "key2": {
+      "type": "string"
+    },
+    "key3": {
+      "type": "string"
+    },
+    "field1": {
+      "type": "string"
+    },
+    "field2": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "key1",
+    "key2",
+    "key3"
+  ]
+}

--- a/tests/test_tap.py
+++ b/tests/test_tap.py
@@ -1,6 +1,11 @@
+import json
+
 from tap_rest_api_msdk.tap import TapRestApiMsdk
 
 from tests.test_streams import config, setup_api
+
+with open("tests/schema.json", "r") as f:
+    BASIC_SCHEMA = json.load(f)
 
 
 def test_schema_inference(requests_mock):
@@ -10,18 +15,25 @@ def test_schema_inference(requests_mock):
         0
     ]
 
-    assert stream0.schema == {
-        "$schema": "http://json-schema.org/schema#",
-        "required": ["key1", "key2", "key3"],
-        "type": "object",
-        "properties": {
-            "field1": {"type": "string"},
-            "field2": {"type": "integer"},
-            "key1": {"type": "string"},
-            "key2": {"type": "string"},
-            "key3": {"type": "string"},
-        },
-    }
+    assert stream0.schema == BASIC_SCHEMA
+
+
+def test_schema_from_file():
+    configs = config()
+    configs["streams"][0]["schema"] = "tests/schema.json"
+
+    s0 = TapRestApiMsdk(config=configs, parse_env_config=True).discover_streams()[0]
+
+    assert s0.schema == BASIC_SCHEMA
+
+
+def test_schema_from_object():
+    configs = config()
+    configs["streams"][0]["schema"] = BASIC_SCHEMA
+
+    s0 = TapRestApiMsdk(config=configs, parse_env_config=True).discover_streams()[0]
+
+    assert s0.schema == BASIC_SCHEMA
 
 
 def test_multiple_streams(requests_mock):


### PR DESCRIPTION
Each stream's schema can now be provided in several ways:

1. The original auto inference feature
2. Provide a path to a json file with a valid json/Singer schema
3. Provide the actual dictionary based json/Singer schema

Thanks to @freimer for providing the issue and inspiration. Resolves #7 and closes #8.

This does not break existing functionality.