### PR TITLE
Add support for next_page_token_path for Simple Header Paginator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-## Forked to support simple header pagination for Bluessnap api - changed streams.py get_new_paginator to:
-          elif (
-            self.pagination_request_style == "simple_header_paginator"
-        ):  # Example Gitlab.com
-            return SimpleHeaderPaginator(self.next_page_token_jsonpath)
-
 # tap-rest-api-msdk
 ![singer_rest_api_tap](https://user-images.githubusercontent.com/84364906/220881634-c0d0145a-ab85-44e9-91b6-e8d365da25f3.png)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+## Forked to support simple header pagination for Bluessnap api - changed streams.py get_new_paginator to:
+          elif (
+            self.pagination_request_style == "simple_header_paginator"
+        ):  # Example Gitlab.com
+            return SimpleHeaderPaginator(self.next_page_token_jsonpath)
+
 # tap-rest-api-msdk
 ![singer_rest_api_tap](https://user-images.githubusercontent.com/84364906/220881634-c0d0145a-ab85-44e9-91b6-e8d365da25f3.png)
 

--- a/tap_rest_api_msdk/streams.py
+++ b/tap_rest_api_msdk/streams.py
@@ -287,7 +287,10 @@ class DynamicStream(RestApiStream):
         elif (
             self.pagination_request_style == "simple_header_paginator"
         ):  # Example Gitlab.com
-            return SimpleHeaderPaginator(self.next_page_token_jsonpath)
+            if self.next_page_token_jsonpath:
+                return JSONPathPaginator(self.next_page_token_jsonpath)
+
+            return SimpleHeaderPaginator("X-Next-Page")
         elif self.pagination_request_style == "header_link_paginator":
             return HeaderLinkPaginator()
         elif (

--- a/tap_rest_api_msdk/streams.py
+++ b/tap_rest_api_msdk/streams.py
@@ -287,7 +287,7 @@ class DynamicStream(RestApiStream):
         elif (
             self.pagination_request_style == "simple_header_paginator"
         ):  # Example Gitlab.com
-            return SimpleHeaderPaginator("X-Next-Page")
+            return SimpleHeaderPaginator(self.next_page_token_jsonpath)
         elif self.pagination_request_style == "header_link_paginator":
             return HeaderLinkPaginator()
         elif (


### PR DESCRIPTION
Adding next_page_token_jsonpath as the default value of SimpleHeaderPaginator key arg. If next_page_token_jsonpath is null,  the value will be "X-Next-Page".