### PR TITLE
Fixing oauth authentication due to sdk framework change

### DIFF
--- a/tap_rest_api_msdk/auth.py
+++ b/tap_rest_api_msdk/auth.py
@@ -116,6 +116,16 @@ class AWSConnectClient:
 
 class ConfigurableOAuthAuthenticator(OAuthAuthenticator):
     """Configurable OAuth Authenticator."""
+    
+    def get_initial_oauth_token(self):
+        """Gets a oauth token for the tap schema discovery.
+
+        Requests an oauth token and sets the auth headers.
+        """
+        if not self.is_token_valid():
+            self.update_access_token()
+
+        self.auth_headers["Authorization"] = f"Bearer {self.access_token}"
 
     @property
     def oauth_request_body(self) -> dict:

--- a/tap_rest_api_msdk/tap.py
+++ b/tap_rest_api_msdk/tap.py
@@ -582,6 +582,10 @@ class TapRestApiMsdk(Tap):
             # Obtaining Authenticator for authorisation to obtain a schema.
             get_authenticator(self)
 
+            # Get an initial oauth token if an oauth method
+            if auth_method == 'oauth':
+                self._authenticator.get_initial_oauth_token()
+
             headers.update(getattr(self._authenticator, "auth_headers", {}))
             params.update(getattr(self._authenticator, "auth_params", {}))
 


### PR DESCRIPTION
This PR resolves an issue with OAuth authentication due to changes in the way the SDK framework has been reconfigured for OAuth and setting setting headers. Bumping the Meltano SDK from 0.33 -> 0.44 introduced a breaking change for this tap.

An OAuth token is initially required to authenticate with requests to obtain a schema layout. This change requests a refresh of the token and ensures the OAuth Request is stored in the header for future requests.

This PR resolves #57